### PR TITLE
Switch from emacs-git to emacs-unstable on emacs-overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,9 @@
         unstablePkgs = unstable.legacyPackages.${system};
       in {
         packages = {
-          emacs = inputs.emacs-overlay.packages.${system}.emacs-git;
+          emacs = inputs.emacs-overlay.packages.${system}.emacs-unstable;
 
-          emacs-pgtk = inputs.emacs-overlay.packages.${system}.emacs-pgtk;
+          emacs-pgtk = inputs.emacs-overlay.packages.${system}.emacs-unstable-pgtk;
 
           registry = pkgs.callPackage ./registry.nix {};
 


### PR DESCRIPTION
I don't want to get exposed to temporary bugs on Emacs master, so I will switch from the latest master to a more stable unreleased version of Emacs.