### PR TITLE
Revert the latest PR for downgrading to emacs-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,9 @@
         unstablePkgs = unstable.legacyPackages.${system};
       in {
         packages = {
-          emacs = inputs.emacs-overlay.packages.${system}.emacs-unstable;
+          emacs = inputs.emacs-overlay.packages.${system}.emacs-git;
 
-          emacs-pgtk = inputs.emacs-overlay.packages.${system}.emacs-unstable-pgtk;
+          emacs-pgtk = inputs.emacs-overlay.packages.${system}.emacs-pgtk;
 
           registry = pkgs.callPackage ./registry.nix {};
 


### PR DESCRIPTION
This reverts commit 0781895c72399a1999949fc8d0b9459a7df641a2.