### PR TITLE
Temporarily replace tree-sitter with an updated version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -506,6 +506,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-tree-sitter": {
+      "locked": {
+        "lastModified": 1701013863,
+        "narHash": "sha256-/77y0qQ/uWFPueG6Mew8BVnNYvR7t7J+21VQqRZWS5Q=",
+        "owner": "akirak",
+        "repo": "nixpkgs",
+        "rev": "4660d83b6d4ecad0c2381ef683e3fef173f21454",
+        "type": "github"
+      },
+      "original": {
+        "owner": "akirak",
+        "ref": "tree-sitter-20231128",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1700108881,
@@ -594,6 +610,7 @@
         "home-manager-unstable": "home-manager-unstable",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_6",
+        "nixpkgs-tree-sitter": "nixpkgs-tree-sitter",
         "stable": "stable",
         "systems": "systems_5",
         "unstable": "unstable"

--- a/flake.lock
+++ b/flake.lock
@@ -267,11 +267,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699870697,
-        "narHash": "sha256-qvwkVzpRJ69deq2cK+dQVpD9mVFHpvviDTuH9eQ/9IQ=",
+        "lastModified": 1700479562,
+        "narHash": "sha256-poiKVA/MCNAp4FhtTO2ia/uSbQ7Zp2og0xFTvJVG9WM=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "de5706cf3f36e7b67d149ec15298e35943ba4289",
+        "rev": "0a2fc7d6a8483ae58c00600bcacf39cd2b7afd31",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700240115,
-        "narHash": "sha256-zdCu7VHHD6Qs81XZMpzlgzUXe1MORAFkpYFQ1Uo8cS0=",
+        "lastModified": 1700991469,
+        "narHash": "sha256-Dx0Doh515JsHUr5NUigw1DX7lNy/WyA9nATki3Nnnrg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dc6576424d581145d8f9601974f39a979a1a4e7b",
+        "rev": "88dc6d6095da5b9436c69c47b44558230fa4fee7",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     "emacs-release-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1699819902,
-        "narHash": "sha256-pDBCwgEjWExmaDnJMOMz+UwcIOGiNHShwIF9V66AwDw=",
+        "lastModified": 1700388876,
+        "narHash": "sha256-OPKS23FHr/PehJcNO+EM82zNcphgGO3y0nXlcj0hxEs=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "5bebd292c63c9a54430854d7d63d01e6f6727e53",
+        "rev": "e521669fb3f5fea6f7b9ee88cbcbcf2750c00f9d",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
     "emacs-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1699859929,
-        "narHash": "sha256-eeeqQGIgYbJNbecFhptkLMg362+4sl7NS+Hho2FUxl0=",
+        "lastModified": 1700470044,
+        "narHash": "sha256-bYdJiyvpggwtvgT2iTfpTFhysP5DFzB3QAxjI4eklRM=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "4dc26a1e6e11416ea631121e46e2084d4fc29203",
+        "rev": "ea7a52dbaed378b51cb0bab33afb34cc3a7c3e7e",
         "type": "github"
       },
       "original": {
@@ -423,11 +423,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1699748081,
-        "narHash": "sha256-MOmMapBydd7MTjhX4eeQZzKlCABWw8W6iSHSG4OeFKE=",
+        "lastModified": 1700392168,
+        "narHash": "sha256-v5LprEFx3u4+1vmds9K0/i7sHjT0IYGs7u9v54iz/OA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04bac349d585c9df38d78e0285b780a140dc74a4",
+        "rev": "28535c3a34d79071f2ccb68671971ce0c0984d7e",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1700118404,
-        "narHash": "sha256-XkqpZpVoy1FV7UbiLkP+fQxxv/6KnwLYkFEHgE8z2IQ=",
+        "lastModified": 1700900274,
+        "narHash": "sha256-KWoKDP5I1viHR4bG3ENnJ7H1DD16tXWH4ROvS0IfXw8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1a033122df8a3c74fda3780c83a104a7d60873c",
+        "rev": "a462e7315deaa8194b0821f726709bb7e51a850c",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699867978,
-        "narHash": "sha256-+arl45HUOcBdKiRGrKXZYXDyBQ6MQGkYPZa/28f6Yzo=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e67f2bf515343da378c3f82f098df8ca01bccc5f",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {
@@ -492,11 +492,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700097215,
-        "narHash": "sha256-ODQ3gBTv1iHd7lG21H+ErVISB5wVeOhd/dEogOqHs/I=",
+        "lastModified": 1700851152,
+        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fb122519e9cd465d532f736a98c1e1eb541ef6f",
+        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
         "type": "github"
       },
       "original": {
@@ -524,11 +524,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1700108881,
-        "narHash": "sha256-+Lqybl8kj0+nD/IlAWPPG/RDTa47gff9nbei0u7BntE=",
+        "lastModified": 1700097215,
+        "narHash": "sha256-ODQ3gBTv1iHd7lG21H+ErVISB5wVeOhd/dEogOqHs/I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7414e9ee0b3e9903c24d3379f577a417f0aae5f1",
+        "rev": "9fb122519e9cd465d532f736a98c1e1eb541ef6f",
         "type": "github"
       },
       "original": {
@@ -538,11 +538,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1699963925,
-        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
+        "lastModified": 1700794826,
+        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
+        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1697456312,
-        "narHash": "sha256-roiSnrqb5r+ehnKCauPLugoU8S36KgmWraHgRqVYndo=",
+        "lastModified": 1700204040,
+        "narHash": "sha256-xSVcS5HBYnD3LTer7Y2K8ZQCDCXMa3QUD1MzRjHzuhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca012a02bf8327be9e488546faecae5e05d7d749",
+        "rev": "c757e9bd77b16ca2e03c89bf8bc9ecb28e0c06ad",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1700097215,
-        "narHash": "sha256-ODQ3gBTv1iHd7lG21H+ErVISB5wVeOhd/dEogOqHs/I=",
+        "lastModified": 1700851152,
+        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fb122519e9cd465d532f736a98c1e1eb541ef6f",
+        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
         "type": "github"
       },
       "original": {
@@ -618,11 +618,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1700097215,
-        "narHash": "sha256-ODQ3gBTv1iHd7lG21H+ErVISB5wVeOhd/dEogOqHs/I=",
+        "lastModified": 1700851152,
+        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fb122519e9cd465d532f736a98c1e1eb541ef6f",
+        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
         "elisp-helpers": "elisp-helpers"
       },
       "locked": {
-        "lastModified": 1699725197,
-        "narHash": "sha256-CG9iEXfvTmCIWh2G8RtZ+TpHdHhBugf9nVYRY30GJ3c=",
+        "lastModified": 1700933422,
+        "narHash": "sha256-Pe5XZxQzOy+6wgG+5lP5bCRIs3ymje6F+Y24Xdi/PSw=",
         "owner": "emacs-twist",
         "repo": "twist.nix",
-        "rev": "9c3c6ba7b07e84c38ee0eca3495c91ea4d0c18ce",
+        "rev": "c709569dd9410a20dd0c1e4cdb2a4e73da88eb9b",
         "type": "github"
       },
       "original": {
@@ -727,11 +727,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1699963925,
-        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
+        "lastModified": 1700794826,
+        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
+        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     stable.url = "github:NixOS/nixpkgs/nixos-23.05";
     unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-tree-sitter.url = "github:akirak/nixpkgs/tree-sitter-20231128";
 
     home-manager-stable.url = "github:nix-community/home-manager/release-23.05";
     home-manager-unstable.url = "github:nix-community/home-manager";
@@ -53,12 +54,23 @@
     // flake-utils.lib.eachSystem (import systems) (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
-        unstablePkgs = unstable.legacyPackages.${system};
+        unstablePkgs = import unstable {
+          inherit system;
+          overlays = [
+            (_: prev: {
+              tree-sitter = assert (prev.tree-sitter.version == "0.20.8");
+                inputs.nixpkgs-tree-sitter.legacyPackages.${system}.tree-sitter;
+            })
+            inputs.emacs-overlay.overlays.default
+          ];
+        };
       in {
         packages = {
-          emacs = inputs.emacs-overlay.packages.${system}.emacs-git;
+          # emacs = inputs.emacs-overlay.packages.${system}.emacs-git;
+          emacs = unstablePkgs.emacs-git;
 
-          emacs-pgtk = inputs.emacs-overlay.packages.${system}.emacs-pgtk;
+          # emacs-pgtk = inputs.emacs-overlay.packages.${system}.emacs-pgtk;
+          emacs-pgtk = unstablePkgs.emacs-pgtk;
 
           registry = pkgs.callPackage ./registry.nix {};
 


### PR DESCRIPTION
The upstream repository of tree-sitter hasn't been setting a tag, and nixpkgs only contains the last tagged version of tree-sitter. I will build Emacs with the latest master of tree-sitter to check if it fixes a certain bug in typescript-ts-mode.