### PR TITLE
ci(dispatch): Dispatch checks in flake-templates

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -12,15 +12,19 @@ jobs:
   dispatch:
     strategy:
       matrix:
-        repo:
+        include:
         # The flake update in emacs-config should trigger subsequent updates in
         # akirak/homelab as well. See
         # <https://github.com/akirak/emacs-config/commit/1a8c71755a9b055d2839b4dc5d8b57f4838cda44>.
-        - akirak/emacs-config
+        - repo: akirak/emacs-config
+          event: flake-update
+        - repo: akirak/flake-templates
+          event: check
+
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
           repository: ${{ matrix.repo }}
-          event-type: flake-update
+          event-type: ${{ matrix.event }}


### PR DESCRIPTION
This enables checks in the flake templates after the flake inputs in this repository are updated. It depends on `repository_dispatch` event added in https://github.com/akirak/flake-templates/pull/79.